### PR TITLE
add main as default skip branch

### DIFF
--- a/git-prune-merged
+++ b/git-prune-merged
@@ -4,7 +4,7 @@
 
 MAIN_BANCH="${1:-HEAD}"
 
-DEFAULT_SKIP_BRANCHES="master dev"
+DEFAULT_SKIP_BRANCHES="master main dev"
 SKIP_BRANCHES="${SKIP_BRANCHES:-${DEFAULT_SKIP_BRANCHES}}"
 
 echo "Main branch: ${MAIN_BANCH}"


### PR DESCRIPTION
It's become popular ever since the whole master/slave controversy. I though it was the new default but I just tested it and github still has master as the default. Not sure what's going on there.